### PR TITLE
Placeholder diff calc

### DIFF
--- a/osu.Game.Rulesets.Diva/Difficulty/DivaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Diva/Difficulty/DivaDifficultyCalculator.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Diva
             double od = beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty;
 
             double difficulty = 1;
-            
+            //TODO: This will need to be rewritten once we start work on #9
             if (od > 6.0d)
             {
                 difficulty = 4;

--- a/osu.Game.Rulesets.Diva/Difficulty/DivaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Diva/Difficulty/DivaDifficultyCalculator.cs
@@ -18,9 +18,23 @@ namespace osu.Game.Rulesets.Diva
         {
         }
 
-        protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
-        {
-            return new DifficultyAttributes(mods, skills, 0);
+        protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate) {
+            double od = beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty;
+
+            double difficulty = 1;
+            
+            if (od > 6.0d)
+            {
+                difficulty = 4;
+            } else if (od > 4.5d)
+            {
+                difficulty = 3;
+            } else if (od > 2d)
+            {
+                difficulty = 2;
+            }
+            
+            return new DifficultyAttributes(mods, skills, difficulty);
         }
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate) => Enumerable.Empty<DifficultyHitObject>();

--- a/osu.Game.Rulesets.Diva/osu.Game.Rulesets.Diva.csproj
+++ b/osu.Game.Rulesets.Diva/osu.Game.Rulesets.Diva.csproj
@@ -13,7 +13,7 @@
     <Folder Include="Resources\Textures" />
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="ppy.osu.Game" Version="2021.331.0"/>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.331.0"/>
+      <PackageReference Include="ppy.osu.Game" Version="2021.331.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.331.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Just shows the number of keys required, which in my experience with a bunch of maps *roughly* can show the basic difficulty, as the more keys, the more you have to keep track of
At the very least it stops everything from being 0