### PR TITLE
Added max press judgement offset

### DIFF
--- a/osu.Game.Rulesets.Diva/Objects/Drawables/DrawableDivaHitObject.cs
+++ b/osu.Game.Rulesets.Diva/Objects/Drawables/DrawableDivaHitObject.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Diva.Objects.Drawables
     {
         private const double time_preempt = 850;
         private const double time_fadein = 300;
+        private const double time_action = 150;
 
         public override bool HandlePositionalInput => false;
 
@@ -142,17 +143,14 @@ namespace osu.Game.Rulesets.Diva.Objects.Drawables
 
             var result = HitObject.HitWindows.ResultFor(timeOffset);
 
-            //result = HitResult.Perfect; // for testing cus i'm noob
+            if (result == HitResult.None) return;
 
-            if(result == HitResult.None) return;
-
-            if(pressed)
+            if (pressed && timeOffset > (-time_action))
             {
                 if(validPress)
                     ApplyResult(r => r.Type = result);
-                else if(HitObject.HitWindows.CanBeHit(timeOffset))
+                else
                     ApplyResult(r => r.Type = HitResult.Miss);
-
                 pressed = false;
             }
         }


### PR DESCRIPTION
This fixes #16 by requiring all presses only be judged if they happen at least `time_action` ms before the note time -- not doing so would create unintended misses.