### PR TITLE
Drop custom hit offsets in favor of osu!mania's defaults

### DIFF
--- a/osu.Game.Rulesets.Diva/Scoring/DivaHitWindows.cs
+++ b/osu.Game.Rulesets.Diva/Scoring/DivaHitWindows.cs
@@ -5,21 +5,18 @@ namespace osu.Game.Rulesets.Diva.Scoring
 {
     public class DivaHitWindows : HitWindows
     {
-        protected override DifficultyRange[] GetRanges() => new DifficultyRange[]
-        {
-            new(HitResult.Great, 80, 50, 20),
-            new(HitResult.Ok, 140, 100, 60),
-            new(HitResult.Meh, 200, 150, 100),
-            new(HitResult.Miss, 400, 400, 400),
-        };
-
-        public override bool IsHitResultAllowed(HitResult result) =>
-            result switch {
-                HitResult.Great => true,
-                HitResult.Ok => true,
-                HitResult.Meh => true,
-                HitResult.Miss => true,
-                _ => false
-            };
+        public override bool IsHitResultAllowed(HitResult result) {
+            switch (result) 
+            {
+            case HitResult.Perfect:
+            case HitResult.Great:
+            case HitResult.Good:
+            case HitResult.Ok:
+            case HitResult.Meh:
+            case HitResult.Miss:
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Hear me out

After playtesting for a bit, I found osu!classic's accuracy offsets were too easy to hit, even compared to the equivalent osu!classic map -- the challenge just isn't as strong.

Also, "Great" on the current codebase doesn't give 100% accuracy and I'm too lazy to figure out why